### PR TITLE
Update make_key to work on Darwin and similar OSes

### DIFF
--- a/tools/make_key
+++ b/tools/make_key
@@ -37,13 +37,14 @@ fi
 # and .pk8-creating programs, to avoid having the private key ever
 # touch the disk.
 
-tmpdir=$(mktemp -d)
+tmpdir=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+
 trap 'rm -rf ${tmpdir}; echo; exit 1' EXIT INT QUIT
 
 one=${tmpdir}/one
 two=${tmpdir}/two
-mknod ${one} p
-mknod ${two} p
+mknod ${one} p 2>/dev/null || mkfifo ${one}
+mknod ${two} p 2>/dev/null || mkfifo ${two}
 chmod 0600 ${one} ${two}
 
 read -p "Enter password for '$1' (blank for none; password will be visible): " \


### PR DESCRIPTION
use `mkfifo` instead of `mknod` and `mktemp -d -t` instead of `mktemp -d` for Darwin.

We get the following errors running `make_key` on a Mac:

```
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix 
mknod: node type must be 'b' or 'c' or 'w'.
mknod: node type must be 'b' or 'c' or 'w'.
chmod: /one: No such file or directory
chmod: /two: No such file or directory
```

The Mac versions of `mktemp` and `mknod` are different so I created some quick changes to make `make_key` system agnostic.
